### PR TITLE
Fix/execute trading

### DIFF
--- a/src/multi_agent/investment_strategy_agent/tools/account.py
+++ b/src/multi_agent/investment_strategy_agent/tools/account.py
@@ -58,7 +58,7 @@ class GetAccountInfoTool(BaseTool):
         if account_info is None:
             return "There is no account information available."
         
-        if account_info == "기간이 만료된 token 입니다.":
+        if "유효하지 않은 token" in account_info:
             user_info['kis_access_token'] = await get_access_token(user_info['kis_app_key'], user_info['kis_app_secret'])
             account_info = await check_account_balance(user_info['kis_app_key'], user_info['kis_app_secret'], user_info['kis_access_token'], user_info['account_no'])
             update_access_token_flag = True

--- a/src/multi_agent/utils.py
+++ b/src/multi_agent/utils.py
@@ -187,8 +187,6 @@ def place_order(stock_code:str, order_side:str, order_type:str, order_price:floa
         "ORD_QTY": str(order_quantity),  # 주문수량
         "ORD_UNPR": str(order_price) if isinstance(order_price, int) else "0",  # 주문 단가 
     }
-    # hashkey 생성
-    hash_key = get_hashkey(kis_app_key, kis_app_secret, body, url)
 
     headers = {
         "Content-Type": "application/json",
@@ -196,15 +194,10 @@ def place_order(stock_code:str, order_side:str, order_type:str, order_price:floa
         "appKey": kis_app_key,
         "appSecret": kis_app_secret,
         "tr_id": tr_id,  # 모의투자 매수 - VTTC0802U / 모의투자 매도 - VTTC0011U
-        "custtype": "P",
-        "hashkey": hash_key
+        "custtype": "P"
     }
     res = requests.post(url, headers=headers, data=json.dumps(body))
-    if res.status_code == 200:
-        res_data = res.json()
-        return res_data['msg1']
-    else:
-        return "주문 요청 실패"
+    return res.json()['msg1']
     
 
 def custom_add_messages(existing: list, update: list):

--- a/src/upload_user.py
+++ b/src/upload_user.py
@@ -25,19 +25,33 @@ def upload_sample_user():
     engine = create_engine(os.environ["DATABASE_URL"])
     SessionLocal = sessionmaker(bind=engine)
     session = SessionLocal()
-    # 샘플 데이터 생성
-    user = User(
-        id=1,
-        kis_app_key=os.getenv("KIS_APP_KEY"),
-        kis_app_secret=os.getenv("KIS_APP_SECRET"),
-        kis_access_token=os.getenv("KIS_ACCESS_TOKEN"),
-        account_no=os.getenv("KIS_ACCOUNT_NO"),
-        investor_type="beginner"
-    )
-    session.add(user)
-    session.commit()
-    session.close()
-    print("샘플 사용자 데이터가 업로드되었습니다.")
+    
+    try:
+        # id=1인 기존 사용자 확인 및 삭제
+        existing_user = session.query(User).filter(User.id == 1).first()
+        if existing_user:
+            session.delete(existing_user)
+            session.commit()
+            print("기존 사용자 데이터(id=1)가 삭제되었습니다.")
+        
+        # 새로운 샘플 데이터 생성
+        user = User(
+            id=1,
+            kis_app_key=os.getenv("KIS_APP_KEY"),
+            kis_app_secret=os.getenv("KIS_APP_SECRET"),
+            kis_access_token=os.getenv("KIS_ACCESS_TOKEN"),
+            account_no=os.getenv("KIS_ACCOUNT_NO"),
+            investor_type="beginner"
+        )
+        session.add(user)
+        session.commit()
+        print("새로운 샘플 사용자 데이터가 업로드되었습니다.")
+        
+    except Exception as e:
+        session.rollback()
+        print(f"데이터 업로드 중 오류가 발생했습니다: {e}")
+    finally:
+        session.close()
 
 if __name__ == "__main__":
     upload_sample_user()


### PR DESCRIPTION
## 개발 이유
- 한투 api 관련 tool 사용시 에러 발생
- AnalysisFinancialStatementTool 에서 가장 최근 연간보고서를 불러오는 코드에서 연도가 하드코딩 되어 있음

## 개발 내용
- place_order 함수에서 get_hashkey 함수를 사용하는데 이때 에러 발생, api 문서에서 hash key를 사용안해도 된다고 나와 있어서 삭제
- supervisor agent에서 execute_trading 할 때 access token을 발급받는 로직이 없어서 추가
- 한투 api 사용시 access token이 만료되었는지 확인하는 로직에서 문구가 틀린 문제 수정
- AnalysisFinancialStatementTool 에서 현재 년도부터 최대 5년까지 순차적으로 데이터를 불러오도록 수정